### PR TITLE
Fix docs.rs link and team name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 This project is developed and maintained by the [Resources team][team].
 
-## [Documentation](https://docs.rs/crate/mutex-trait)
+## [Documentation](https://docs.rs/mutex-trait)
 
 ## License
 
@@ -28,7 +28,7 @@ additional terms or conditions.
 ## Code of Conduct
 
 Contribution to this crate is organized under the terms of the [Rust Code of
-Conduct][CoC], the maintainer of this crate, the [Cortex-M team][team], promises
+Conduct][CoC], the maintainer of this crate, the [Resources team][team], promises
 to intervene to uphold that code of conduct.
 
 [CoC]: CODE_OF_CONDUCT.md


### PR DESCRIPTION
Closes #3, though the link remains broken until this crate is published in crates.io. Additionally fix the team name in README that I noticed while I was there.